### PR TITLE
ObjectFilterの対象がフォルダの時にフォルダ名を含んだ別フォルダやアセットを含んでしまう問題の修正

### DIFF
--- a/Assets/SmartAddresser/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/ObjectBasedAssetFilter.cs
+++ b/Assets/SmartAddresser/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/ObjectBasedAssetFilter.cs
@@ -64,7 +64,7 @@ namespace SmartAddresser.Editor.Core.Models.Shared.AssetGroups.AssetFilterImpl
                 if (objectIsFolder)
                 {
                     var isInclusion = !isSelf && !isFolder &&
-                                      assetPath.StartsWith(objectAssetPath, StringComparison.Ordinal);
+                                      assetPath.StartsWith(objectAssetPath + "/", StringComparison.Ordinal);
                     switch (FolderTargetingMode)
                     {
                         case FolderTargetingMode.IncludedNonFolderAssets:
@@ -72,11 +72,11 @@ namespace SmartAddresser.Editor.Core.Models.Shared.AssetGroups.AssetFilterImpl
                                 return true;
                             break;
                         case FolderTargetingMode.Self:
-                            if (isSelf)
+                            if (isSelf && isFolder)
                                 return true;
                             break;
                         case FolderTargetingMode.Both:
-                            if (isInclusion || isSelf)
+                            if (isInclusion || (isSelf && isFolder))
                                 return true;
                             break;
                         default:

--- a/Assets/SmartAddresser/Tests/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/ObjectBasedAssetFilterTest.cs
+++ b/Assets/SmartAddresser/Tests/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/ObjectBasedAssetFilterTest.cs
@@ -40,6 +40,25 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Shared.AssetGroups.AssetFilter
             return filter.IsMatch(assetPath, assetType, assetType == typeof(DefaultAsset));
         }
 
+        [TestCase(FolderTargetingMode.IncludedNonFolderAssets, TestAssetRelativePaths.Dummy1.Folder, typeof(DefaultAsset), ExpectedResult = false)]
+        [TestCase(FolderTargetingMode.IncludedNonFolderAssets, TestAssetRelativePaths.Dummy1.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
+        [TestCase(FolderTargetingMode.IncludedNonFolderAssets, TestAssetRelativePaths.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
+        [TestCase(FolderTargetingMode.Self, TestAssetRelativePaths.Dummy1.Folder, typeof(DefaultAsset), ExpectedResult = false)]
+        [TestCase(FolderTargetingMode.Self, TestAssetRelativePaths.Dummy1.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
+        [TestCase(FolderTargetingMode.Self, TestAssetRelativePaths.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
+        [TestCase(FolderTargetingMode.Both, TestAssetRelativePaths.Dummy1.Folder, typeof(DefaultAsset), ExpectedResult = false)]
+        [TestCase(FolderTargetingMode.Both, TestAssetRelativePaths.Dummy1.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
+        [TestCase(FolderTargetingMode.Both, TestAssetRelativePaths.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
+        public bool IsMatch_ObjectIsFolder_ContainsFilterDirectoryName_ReturnFalse(FolderTargetingMode targetingMode, string relativeAssetPath, Type assetType)
+        {
+            var filter = new ObjectBasedAssetFilter();
+            filter.FolderTargetingMode = targetingMode;
+            filter.Object.Value = AssetDatabase.LoadAssetAtPath<Object>(TestAssetPaths.Dummy.Folder);
+            filter.SetupForMatching();
+            var assetPath = TestAssetPaths.CreateAbsoluteAssetPath(relativeAssetPath);
+            return filter.IsMatch(assetPath, assetType, assetType == typeof(DefaultAsset));
+        }
+
         [Test]
         public void IsMatch_RegisterNotMatchedObject_ReturnFalse()
         {
@@ -69,6 +88,16 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Shared.AssetGroups.AssetFilter
             filter.Object.AddValue(AssetDatabase.LoadAssetAtPath<Object>(TestAssetPaths.Shared.Texture256));
             filter.SetupForMatching();
             Assert.That(filter.IsMatch(TestAssetPaths.Shared.Texture64, typeof(Texture2D), false), Is.False);
+        }
+        
+        [Test]
+        public void IsMatch_AnotherDirectoryContainsFilterDirectoryName_ReturnFalse()
+        {
+            var filter = new ObjectBasedAssetFilter();
+            filter.Object.IsListMode = true;
+            filter.Object.AddValue(AssetDatabase.LoadAssetAtPath<Object>(TestAssetPaths.Dummy.Folder));
+            filter.SetupForMatching();
+            Assert.That(filter.IsMatch(TestAssetPaths.Dummy1.PrefabDummy, typeof(GameObject), false), Is.False);
         }
     }
 }

--- a/Assets/SmartAddresser/Tests/Editor/Core/TestAssetPaths.cs
+++ b/Assets/SmartAddresser/Tests/Editor/Core/TestAssetPaths.cs
@@ -10,6 +10,7 @@ namespace SmartAddresser.Tests.Editor.Core
 {
     public static class TestAssetRelativePaths
     {
+        public const string PrefabDummy = "Dummy";
         public static class Shared
         {
             public const string Folder = "Shared";
@@ -24,6 +25,12 @@ namespace SmartAddresser.Tests.Editor.Core
         {
             public const string Folder = "Dummy";
             public const string PrefabDummy = Folder + "/prefab_dummy.prefab";
+        }
+        
+        public static class Dummy1
+        {
+            public const string Folder = "Dummy1";
+            public const string PrefabDummy = Folder + "/prefab_dummy_1.prefab";
         }
     }
 
@@ -50,6 +57,7 @@ namespace SmartAddresser.Tests.Editor.Core
             return $"{Folder}/{relativeAssetPath}";
         }
 
+        public static string DummyPrefab => CreateAbsoluteAssetPath(TestAssetRelativePaths.PrefabDummy);
         public static class Shared
         {
             public static string Folder => CreateAbsoluteAssetPath(TestAssetRelativePaths.Shared.Folder);
@@ -64,6 +72,12 @@ namespace SmartAddresser.Tests.Editor.Core
         {
             public static string Folder => CreateAbsoluteAssetPath(TestAssetRelativePaths.Dummy.Folder);
             public static string PrefabDummy => CreateAbsoluteAssetPath(TestAssetRelativePaths.Dummy.PrefabDummy);
+        }
+
+        public static class Dummy1
+        {
+            public static string Folder => CreateAbsoluteAssetPath(TestAssetRelativePaths.Dummy1.Folder);
+            public static string PrefabDummy => CreateAbsoluteAssetPath(TestAssetRelativePaths.Dummy1.PrefabDummy);
         }
     }
 }


### PR DESCRIPTION
## 概要
https://github.com/CyberAgentGameEntertainment/SmartAddresser/issues/ 44 の修正を行う 
伴ってテストを追加する
元issueでは触れていない同名アセットに対する修正も含んでいる

## セルフレビュー項目
- [x] 同じ名称を含むディレクトリが対象にならない
- [x] 同じ階層にある同じ名前のプレハブが対象にならない
- [x] テスト通過