### PR TITLE
一括操作を最適化

### DIFF
--- a/Assets/SmartAddresser/Editor/Core/Models/Services/ApplyLayoutRuleService.cs
+++ b/Assets/SmartAddresser/Editor/Core/Models/Services/ApplyLayoutRuleService.cs
@@ -85,6 +85,7 @@ namespace SmartAddresser.Editor.Core.Models.Services
                 if (!_layoutRule.TryProvideAddressAndAddressableGroup(assetPath, assetType, isFolder, doSetup,
                         out _,
                         out var addressableGroup))
+                    continue;
 
                 // If the layout rule is found but the addressable asset group has already been destroyed, return false.
                 if (addressableGroup == null)
@@ -151,6 +152,7 @@ namespace SmartAddresser.Editor.Core.Models.Services
             if (!_layoutRule.TryProvideAddressAndAddressableGroup(assetPath, assetType, isFolder, doSetup,
                     out var address,
                     out var addressableGroup))
+                return false;
 
             // If the layout rule is found but the addressable asset group has already been destroyed, return false.
             if (addressableGroup == null)

--- a/Assets/SmartAddresser/Editor/Core/Models/Services/ApplyLayoutRuleService.cs
+++ b/Assets/SmartAddresser/Editor/Core/Models/Services/ApplyLayoutRuleService.cs
@@ -83,9 +83,8 @@ namespace SmartAddresser.Editor.Core.Models.Services
 
                 // If the layout rule was not found, return false.
                 if (!_layoutRule.TryProvideAddressAndAddressableGroup(assetPath, assetType, isFolder, doSetup,
-                        out _, out var addressableGroup
-                    ))
-                    continue;
+                        out _,
+                        out var addressableGroup))
 
                 // If the layout rule is found but the addressable asset group has already been destroyed, return false.
                 if (addressableGroup == null)
@@ -101,8 +100,7 @@ namespace SmartAddresser.Editor.Core.Models.Services
                         continue;
 
                     // If the version is not satisfied, return false.
-                    if (!string.IsNullOrEmpty(versionText) && Version.TryCreate(versionText, out var version) &&
-                        !comparator.IsSatisfied(version))
+                    if (!string.IsNullOrEmpty(versionText) && Version.TryCreate(versionText, out var version) && !comparator.IsSatisfied(version))
                         continue;
                 }
 
@@ -114,6 +112,7 @@ namespace SmartAddresser.Editor.Core.Models.Services
                 assetGuids.Add(assetGuid);
             }
 
+            // Update entries 
             foreach (var kvp in groupedGuids)
             {
                 var entryAdapters = _addressableSettingsAdapter.CreateOrMoveEntries(kvp.Key, kvp.Value);
@@ -152,7 +151,6 @@ namespace SmartAddresser.Editor.Core.Models.Services
             if (!_layoutRule.TryProvideAddressAndAddressableGroup(assetPath, assetType, isFolder, doSetup,
                     out var address,
                     out var addressableGroup))
-                return false;
 
             // If the layout rule is found but the addressable asset group has already been destroyed, return false.
             if (addressableGroup == null)
@@ -185,17 +183,14 @@ namespace SmartAddresser.Editor.Core.Models.Services
             return true;
         }
 
-        internal void UpdateAssetLabel(IAddressableAssetEntryAdapter entryAdapter, string assetPath, System.Type assetType,
-            bool isFolder, bool doSetup)
+        internal void UpdateAssetLabel(IAddressableAssetEntryAdapter entryAdapter, string assetPath, System.Type assetType, bool isFolder, bool doSetup)
         {
             // Add labels to addressable settings if not exists.
             var labels = _layoutRule.ProvideLabels(assetPath, assetType, isFolder, doSetup);
             var addressableLabels = _addressableSettingsAdapter.GetLabels();
             foreach (var label in labels)
-            {
                 if (!addressableLabels.Contains(label))
                     _addressableSettingsAdapter.AddLabel(label);
-            }
 
             // Remove old labels.
             var oldLabels = entryAdapter.Labels.ToArray();

--- a/Assets/SmartAddresser/Editor/Core/Models/Services/ApplyLayoutRuleService.cs
+++ b/Assets/SmartAddresser/Editor/Core/Models/Services/ApplyLayoutRuleService.cs
@@ -1,9 +1,9 @@
+using System.Collections.Generic;
 using System.Linq;
 using SmartAddresser.Editor.Core.Models.LayoutRules;
 using SmartAddresser.Editor.Foundation.AddressableAdapter;
 using SmartAddresser.Editor.Foundation.AssetDatabaseAdapter;
 using SmartAddresser.Editor.Foundation.SemanticVersioning;
-using UnityEngine;
 
 namespace SmartAddresser.Editor.Core.Models.Services
 {
@@ -55,17 +55,13 @@ namespace SmartAddresser.Editor.Core.Models.Services
 
             // Add all entries to the addressable asset system.
             var versionExpression = _layoutRule.Settings.VersionExpression;
-            foreach (var assetPath in _assetDatabaseAdapter.GetAllAssetPaths())
-            {
-                var guid = _assetDatabaseAdapter.AssetPathToGUID(assetPath);
-                TryAddEntry(guid, false, versionExpression.Value);
-            }
+            TryAddEntries(_assetDatabaseAdapter.GetAllAssetPaths(), false, versionExpression.Value);
         }
 
         /// <summary>
         ///     Apply the layout rule to the addressable settings.
         /// </summary>
-        /// <param name="assetGuid"></param>
+        /// <param name="pathes"></param>
         /// <param name="doSetup">
         ///     If true, setup rules before providing.
         ///     When you call this method multiple times, set this false and call <see cref="Setup" /> before.
@@ -76,9 +72,79 @@ namespace SmartAddresser.Editor.Core.Models.Services
         ///     If the layout rule was applied to the addressable asset system, return true.
         ///     Returns false if no suitable layout rule was found.
         /// </returns>
-        public bool TryAddEntry(string assetGuid, bool doSetup, string versionExpression = null)
+        public void TryAddEntries(string[] pathes, bool doSetup, string versionExpression = null)
         {
-            var assetPath = _assetDatabaseAdapter.GUIDToAssetPath(assetGuid);
+            var groupedGuids = new Dictionary<string, List<string>>();
+            foreach (var assetPath in pathes)
+            {
+                var assetGuid = _assetDatabaseAdapter.AssetPathToGUID(assetPath);
+                var assetType = _assetDatabaseAdapter.GetMainAssetTypeAtPath(assetPath);
+                var isFolder = _assetDatabaseAdapter.IsValidFolder(assetPath);
+
+                // If the layout rule was not found, return false.
+                if (!_layoutRule.TryProvideAddressAndAddressableGroup(assetPath, assetType, isFolder, doSetup,
+                        out _, out var addressableGroup
+                    ))
+                    continue;
+
+                // If the layout rule is found but the addressable asset group has already been destroyed, return false.
+                if (addressableGroup == null)
+                    continue;
+
+                // Check the version if it is specified.
+                if (!string.IsNullOrEmpty(versionExpression))
+                {
+                    var comparator = _versionExpressionParser.CreateComparator(versionExpression);
+                    var versionText = _layoutRule.ProvideVersion(assetPath, assetType, isFolder, doSetup);
+
+                    if (string.IsNullOrEmpty(versionText) && _layoutRule.Settings.ExcludeUnversioned.Value)
+                        continue;
+
+                    // If the version is not satisfied, return false.
+                    if (!string.IsNullOrEmpty(versionText) && Version.TryCreate(versionText, out var version) &&
+                        !comparator.IsSatisfied(version))
+                        continue;
+                }
+
+                if (!groupedGuids.TryGetValue(addressableGroup.name, out var assetGuids))
+                {
+                    assetGuids = new List<string>();
+                    groupedGuids.Add(addressableGroup.name, assetGuids);
+                }
+                assetGuids.Add(assetGuid);
+            }
+
+            foreach (var kvp in groupedGuids)
+            {
+                var entryAdapters = _addressableSettingsAdapter.CreateOrMoveEntries(kvp.Key, kvp.Value);
+                foreach (var entryAdapter in entryAdapters)
+                {
+                    var assetPath = entryAdapter.Address;
+                    var assetType = _assetDatabaseAdapter.GetMainAssetTypeAtPath(assetPath);
+                    var isFolder = _assetDatabaseAdapter.IsValidFolder(assetPath);
+                
+                    UpdateAssetLabel(entryAdapter, assetPath, assetType, isFolder, doSetup);
+                }   
+            }
+        }
+
+        /// <summary>
+        ///     Apply the layout rule to the addressable settings.
+        /// </summary>
+        /// <param name="assetPath"></param>
+        /// <param name="doSetup">
+        ///     If true, setup rules before providing.
+        ///     When you call this method multiple times, set this false and call <see cref="Setup" /> before.
+        ///     If you call this method only once, set this true and don't call <see cref="Setup" />.
+        /// </param>
+        /// <param name="versionExpression"></param>
+        /// <returns>
+        ///     If the layout rule was applied to the addressable asset system, return true.
+        ///     Returns false if no suitable layout rule was found.
+        /// </returns>
+        public bool TryAddEntry(string assetPath, bool doSetup, string versionExpression = null)
+        {
+            var assetGuid = _assetDatabaseAdapter.AssetPathToGUID(assetPath);
             var assetType = _assetDatabaseAdapter.GetMainAssetTypeAtPath(assetPath);
             var isFolder = _assetDatabaseAdapter.IsValidFolder(assetPath);
 
@@ -114,12 +180,22 @@ namespace SmartAddresser.Editor.Core.Models.Services
             var entryAdapter = _addressableSettingsAdapter.CreateOrMoveEntry(addressableGroupName, assetGuid);
             entryAdapter.SetAddress(address);
 
+            UpdateAssetLabel(entryAdapter, assetPath, assetType, isFolder, doSetup);
+
+            return true;
+        }
+
+        internal void UpdateAssetLabel(IAddressableAssetEntryAdapter entryAdapter, string assetPath, System.Type assetType,
+            bool isFolder, bool doSetup)
+        {
             // Add labels to addressable settings if not exists.
             var labels = _layoutRule.ProvideLabels(assetPath, assetType, isFolder, doSetup);
             var addressableLabels = _addressableSettingsAdapter.GetLabels();
             foreach (var label in labels)
+            {
                 if (!addressableLabels.Contains(label))
                     _addressableSettingsAdapter.AddLabel(label);
+            }
 
             // Remove old labels.
             var oldLabels = entryAdapter.Labels.ToArray();
@@ -129,8 +205,6 @@ namespace SmartAddresser.Editor.Core.Models.Services
             // Add new labels.
             foreach (var label in labels)
                 entryAdapter.SetLabel(label, true);
-
-            return true;
         }
     }
 }

--- a/Assets/SmartAddresser/Editor/Foundation/AddressableAdapter/AddresableAssetSettingsAdapter.cs
+++ b/Assets/SmartAddresser/Editor/Foundation/AddressableAdapter/AddresableAssetSettingsAdapter.cs
@@ -18,7 +18,7 @@ namespace SmartAddresser.Editor.Foundation.AddressableAdapter
         public AddressableAssetSettingsAdapter(AddressableAssetSettings settings)
         {
             _settings = settings;
-            
+
             _removeAssetEntriesMethod = typeof(AddressableAssetGroup).GetMethod("RemoveAssetEntries", BindingFlags.Instance | BindingFlags.NonPublic);
             _createOrMoveEntriesMethod = typeof(AddressableAssetSettings).GetMethod("CreateOrMoveEntries", BindingFlags.Instance | BindingFlags.NonPublic);
         }
@@ -43,9 +43,9 @@ namespace SmartAddresser.Editor.Foundation.AddressableAdapter
             var group = _settings.FindGroup(groupName);
             var createdEntries = new List<AddressableAssetEntry>();
             var movedEntries = new List<AddressableAssetEntry>();
-            var parameters = new object[] {guids, group, createdEntries, movedEntries, };
+            var parameters = new object[] {guids, group, createdEntries, movedEntries, false, true, };
             _createOrMoveEntriesMethod.Invoke(_settings, parameters);
-            
+
             return createdEntries
                 .Concat(movedEntries)
                 .Where(entry=> entry != null)
@@ -67,7 +67,7 @@ namespace SmartAddresser.Editor.Foundation.AddressableAdapter
 
             // Note: Bulk delete is internal, so call via Reflection
             var entries = group.entries.ToArray();
-            var parameters = new object[] { entries, };
+            var parameters = new object[] { entries, true, };
             _removeAssetEntriesMethod.Invoke(group, parameters);
         }
 

--- a/Assets/SmartAddresser/Editor/Foundation/AddressableAdapter/AddresableAssetSettingsAdapter.cs
+++ b/Assets/SmartAddresser/Editor/Foundation/AddressableAdapter/AddresableAssetSettingsAdapter.cs
@@ -19,7 +19,7 @@ namespace SmartAddresser.Editor.Foundation.AddressableAdapter
         {
             _settings = settings;
             
-            _removeAssetEntriesMethod = typeof(AddressableAssetSettings).GetMethod("RemoveAssetEntries", BindingFlags.Instance | BindingFlags.NonPublic);
+            _removeAssetEntriesMethod = typeof(AddressableAssetGroup).GetMethod("RemoveAssetEntries", BindingFlags.Instance | BindingFlags.NonPublic);
             _createOrMoveEntriesMethod = typeof(AddressableAssetSettings).GetMethod("CreateOrMoveEntries", BindingFlags.Instance | BindingFlags.NonPublic);
         }
 

--- a/Assets/SmartAddresser/Editor/Foundation/AddressableAdapter/AddressableAssetEntryAdapter.cs
+++ b/Assets/SmartAddresser/Editor/Foundation/AddressableAdapter/AddressableAssetEntryAdapter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEditor.AddressableAssets.Settings;
 
@@ -24,12 +25,16 @@ namespace SmartAddresser.Editor.Foundation.AddressableAdapter
         /// <inheritdoc />
         public void SetAddress(string address)
         {
+            if(string.Compare(_entry.AssetPath, address, StringComparison.Ordinal) == 0)
+                return;
             _entry.SetAddress(address);
         }
         
         /// <inheritdoc />
         public bool SetLabel(string label, bool enable)
         {
+            if(_entry.labels.Contains(label) == enable)
+                return true;
             return _entry.SetLabel(label, enable);
         }
     }

--- a/Assets/SmartAddresser/Editor/Foundation/AddressableAdapter/AddressableAssetEntryAdapter.cs
+++ b/Assets/SmartAddresser/Editor/Foundation/AddressableAdapter/AddressableAssetEntryAdapter.cs
@@ -25,7 +25,7 @@ namespace SmartAddresser.Editor.Foundation.AddressableAdapter
         /// <inheritdoc />
         public void SetAddress(string address)
         {
-            if(string.Compare(_entry.AssetPath, address, StringComparison.Ordinal) == 0)
+            if(string.Compare(_entry.address, address, StringComparison.Ordinal) == 0)
                 return;
             _entry.SetAddress(address);
         }

--- a/Assets/SmartAddresser/Editor/Foundation/AddressableAdapter/IAddressableAssetSettingsAdapter.cs
+++ b/Assets/SmartAddresser/Editor/Foundation/AddressableAdapter/IAddressableAssetSettingsAdapter.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using UnityEditor.AddressableAssets.Settings;
 
 namespace SmartAddresser.Editor.Foundation.AddressableAdapter
 {
@@ -22,6 +21,14 @@ namespace SmartAddresser.Editor.Foundation.AddressableAdapter
         /// <param name="guid">The asset guid.</param>
         /// <returns>The created entry adapter.</returns>
         IAddressableAssetEntryAdapter CreateOrMoveEntry(string groupName, string guid);
+        
+        /// <summary>
+        ///     Create a new entries, or if one exists in a different group, move it into the new group.
+        /// </summary>
+        /// <param name="groupName"></param>
+        /// <param name="guids">The asset guids.</param>
+        /// <returns>The created entry adapters.</returns>
+        IEnumerable<IAddressableAssetEntryAdapter> CreateOrMoveEntries(string groupName, IEnumerable<string> guids);
 
         /// <summary>
         ///     Remove an asset entry.

--- a/Assets/SmartAddresser/Tests/Editor/Core/Models/Services/ApplyLayoutRuleServiceTest.cs
+++ b/Assets/SmartAddresser/Tests/Editor/Core/Models/Services/ApplyLayoutRuleServiceTest.cs
@@ -38,7 +38,7 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Services
             var service = new ApplyLayoutRuleService(layoutRule, new UnityVersionExpressionParser(),
                 addressableSettingsAdapter, assetDatabaseAdapter);
 
-            var result = service.TryAddEntry(assetGuid, true);
+            var result = service.TryAddEntry(TestAssetPath, true);
             var assetEntry = addressableSettingsAdapter.FindAssetEntry(assetGuid);
             Assert.That(result, Is.True);
             Assert.That(assetEntry, Is.Not.Null);
@@ -61,7 +61,7 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Services
                 addressableSettingsAdapter, assetDatabaseAdapter);
 
             service.Setup();
-            var result = service.TryAddEntry(assetGuid, false);
+            var result = service.TryAddEntry(TestAssetPath, false);
             var assetEntry = addressableSettingsAdapter.FindAssetEntry(assetGuid);
             Assert.That(result, Is.True);
             Assert.That(assetEntry, Is.Not.Null);
@@ -84,7 +84,7 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Services
             var service = new ApplyLayoutRuleService(layoutRule, new UnityVersionExpressionParser(),
                 addressableSettingsAdapter, assetDatabaseAdapter);
 
-            var result = service.TryAddEntry(assetGuid, true);
+            var result = service.TryAddEntry(TestAssetPath, true);
             Assert.That(result, Is.False);
         }
 
@@ -103,7 +103,7 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Services
             var service = new ApplyLayoutRuleService(layoutRule, new UnityVersionExpressionParser(),
                 addressableSettingsAdapter, assetDatabaseAdapter);
 
-            var result = service.TryAddEntry(assetGuid, true);
+            var result = service.TryAddEntry(TestAssetPath, true);
             Assert.That(result, Is.False);
         }
 
@@ -122,7 +122,7 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Services
             var service = new ApplyLayoutRuleService(layoutRule, new UnityVersionExpressionParser(),
                 addressableSettingsAdapter, assetDatabaseAdapter);
 
-            var result = service.TryAddEntry(assetGuid, true, "[1.2.3,1.2.4)");
+            var result = service.TryAddEntry(TestAssetPath, true, "[1.2.3,1.2.4)");
             var assetEntry = addressableSettingsAdapter.FindAssetEntry(assetGuid);
             Assert.That(result, Is.True);
             Assert.That(assetEntry, Is.Not.Null);
@@ -164,7 +164,7 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Services
             var service = new ApplyLayoutRuleService(layoutRule, new UnityVersionExpressionParser(),
                 addressableSettingsAdapter, assetDatabaseAdapter);
 
-            Assert.That(() => service.TryAddEntry(assetGuid, true, "(1.2.3, 1.3)"), Throws.InstanceOf<Exception>());
+            Assert.That(() => service.TryAddEntry(TestAssetPath, true, "(1.2.3, 1.3)"), Throws.InstanceOf<Exception>());
         }
 
         [Test]
@@ -183,7 +183,7 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Services
             var service = new ApplyLayoutRuleService(layoutRule, new UnityVersionExpressionParser(),
                 addressableSettingsAdapter, assetDatabaseAdapter);
 
-            var result = service.TryAddEntry(assetGuid, true);
+            var result = service.TryAddEntry(TestAssetPath, true);
             var assetEntry = addressableSettingsAdapter.FindAssetEntry(assetGuid);
             Assert.That(result, Is.True);
             Assert.That(assetEntry, Is.Not.Null);

--- a/Assets/SmartAddresser/Tests/Editor/Foundation/FakeAddressableAssetSettingsAdapter.cs
+++ b/Assets/SmartAddresser/Tests/Editor/Foundation/FakeAddressableAssetSettingsAdapter.cs
@@ -35,6 +35,11 @@ namespace SmartAddresser.Tests.Editor.Foundation
             return entry.Adapter;
         }
 
+        public IEnumerable<IAddressableAssetEntryAdapter> CreateOrMoveEntries(string groupName, IEnumerable<string> guids)
+        {
+            return guids.Select(guid => CreateOrMoveEntry(groupName, guid));
+        }
+
         /// <inheritdoc />
         public bool RemoveEntry(string guid)
         {

--- a/Assets/SmartAddresser/Tests/Editor/Foundation/FakeAddressableAssetSettingsAdapter.cs
+++ b/Assets/SmartAddresser/Tests/Editor/Foundation/FakeAddressableAssetSettingsAdapter.cs
@@ -35,6 +35,7 @@ namespace SmartAddresser.Tests.Editor.Foundation
             return entry.Adapter;
         }
 
+        /// <inheritdoc />
         public IEnumerable<IAddressableAssetEntryAdapter> CreateOrMoveEntries(string groupName, IEnumerable<string> guids)
         {
             return guids.Select(guid => CreateOrMoveEntry(groupName, guid));
@@ -46,6 +47,7 @@ namespace SmartAddresser.Tests.Editor.Foundation
             return _guidToEntryMap.Remove(guid);
         }
 
+        /// <inheritdoc />
         public void RemoveAllEntries(string groupName)
         {
             var targetGuids = _guidToEntryMap


### PR DESCRIPTION
#8 #4 を軽減する　手元では11s -> 1.5s ぐらいに
Addressableのinternalに存在している一括操作関数をリフレクションで引き出して実行する事で高速化を行う

以下はdeepでないプロファイラの計測結果
## 軽量パターン
### main
![スクリーンショット 2023-12-22 055750](https://github.com/Rapilias/SmartAddresser/assets/91034223/cf9bb14c-6052-466b-8333-9c44ea22e563)

### optimize/bulk-entry-control
![ce8f1519-b5b2-449c-93af-135c997bb48a](https://github.com/Rapilias/SmartAddresser/assets/91034223/34b02dd2-bcf1-424b-8b9b-f91a669db4ef)

## 重量パターン( #7 )
### main
![スクリーンショット 2023-12-22 063444](https://github.com/Rapilias/SmartAddresser/assets/91034223/c07b5736-3c85-456e-b414-129e8c4dee4e)

### optimize/bulk-entry-control
![スクリーンショット 2023-12-22 063258](https://github.com/Rapilias/SmartAddresser/assets/91034223/767f5211-c55e-4906-ac35-9472ec97efca)

