### PR TITLE
アセット選択時にProjectウインドウの対応するアセットを選択する

### DIFF
--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutViewer/LayoutViewerPresenter.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutViewer/LayoutViewerPresenter.cs
@@ -9,6 +9,7 @@ using SmartAddresser.Editor.Core.Tools.Shared;
 using SmartAddresser.Editor.Foundation.TinyRx;
 using SmartAddresser.Editor.Foundation.TinyRx.ObservableProperty;
 using UnityEditor;
+using UnityEditor.AddressableAssets;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -213,14 +214,22 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutViewer
 
             var id = ids[0];
             var treeViewItem = _view.TreeView.GetItem(id);
-            if (treeViewItem is LayoutViewerTreeView.GroupItem)
+            if (treeViewItem is LayoutViewerTreeView.GroupItem groupItem)
             {
                 _view.Message = string.Empty;
+                var asset = groupItem.Group.AddressableGroup;
+                EditorGUIUtility.PingObject(asset);
+                Selection.activeObject = asset;
                 return;
             }
 
             if (treeViewItem is LayoutViewerTreeView.EntryItem entryItem)
+            {
                 _view.Message = entryItem.Entry.Messages;
+                var asset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(entryItem.Entry.AssetPath);
+                EditorGUIUtility.PingObject(asset);
+                Selection.activeObject = asset;
+            }
         }
     }
 }


### PR DESCRIPTION
#4  #8 の回避
Addressables Groups ウインドウの選択と同等の物を用意する
![gseorighoer](https://github.com/Rapilias/SmartAddresser/assets/91034223/b2b8df92-59a7-4f24-a669-1ae705390433)
